### PR TITLE
feat: expand Buy2Day product loader and watcher to full shop catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ data/
   *.yml                     CI and scheduled automation.
 ```
 
-The files in `tools/` are not browser userscripts. They are repo automation helpers. For example, `scripts/buy2day-product-loader.user.js` changes the Buy2Day page in your browser, while `tools/check-buy2day-products.mjs` runs in Node.js so GitHub Actions can check the catalog on a schedule.
+The files in `tools/` are not browser userscripts. They are repo automation helpers. For example, `scripts/buy2day-product-loader.user.js` enhances the Buy2Day shop page in your browser, while `tools/check-buy2day-products.mjs` runs in Node.js so GitHub Actions can check the full catalog on a schedule.
 
 ## Userscript Installation
 
@@ -28,21 +28,24 @@ The files in `tools/` are not browser userscripts. They are repo automation help
 
 ## Buy2Day Product Loader
 
-Loads in-stock products from Buy2Day rewards pages into one consolidated browser view.
+Loads all eligible in-stock products from Buy2Day into one consolidated browser view.
 
 Context:
 
-- Intended for browsing redeemable in-stock items for Standard Chartered Pakistan credit card rewards.
+- Intended for browsing in-stock items eligible for Standard Chartered Pakistan credit card rewards.
 - Rewards promotion entry page: `https://www.sc.com/pk/promotions/credit-card-rewards/`
 - Script execution targets:
+  - `https://buy2day.pk/shop/*` (full catalog — recommended)
+  - `https://www.buy2day.pk/shop/*`
   - `https://buy2day.pk/product-category/rewards-points-products/*`
   - `https://www.buy2day.pk/product-category/rewards-points-products/*`
 
 Features:
 
--Fetches all catalog pages (per selected WooCommerce sort)
-
+- Fetches all catalog pages (per selected WooCommerce sort)
 - Excludes out-of-stock items
+- Excludes installment-only products (e.g. items marked "installment available")
+- Displays discounted price for sale items; sorts by discounted price
 - Uses Buy2Day’s native sorting
 - Local sort (order, price, name) + client-side search
 - Concurrent loading for speed
@@ -70,7 +73,7 @@ Files:
 How it works:
 
 1. GitHub Actions runs the watcher daily at `05:23 UTC`, or manually from the Actions tab.
-2. The checker reads Buy2Day's public WooCommerce Store API for visible rewards products.
+2. The checker reads Buy2Day's public WooCommerce Store API for all visible shop products, excluding installment-only items.
 3. It compares the current product IDs to `data/buy2day-products.json`.
 4. If new products are found, the workflow opens a GitHub Issue listing them.
 5. The workflow commits the updated snapshot so the next run only reports products added after that point.

--- a/scripts/buy2day-product-loader.user.js
+++ b/scripts/buy2day-product-loader.user.js
@@ -1,10 +1,12 @@
 // ==UserScript==
 // @name         Buy2Day Product Loader
 // @namespace    https://github.com/ali28729/browser-userscripts
-// @version      1.2.2
-// @description  Load all in-stock products and add client-side search and sorting.
+// @version      1.3.0
+// @description  Load all eligible in-stock products from Buy2Day — excludes installment-only items, uses discounted price for sale items.
 // @match        https://buy2day.pk/product-category/rewards-points-products/*
 // @match        https://www.buy2day.pk/product-category/rewards-points-products/*
+// @match        https://buy2day.pk/shop/*
+// @match        https://www.buy2day.pk/shop/*
 // @grant        none
 // @run-at       document-idle
 // @updateURL    https://raw.githubusercontent.com/ali28729/browser-userscripts/main/scripts/buy2day-product-loader.user.js
@@ -75,7 +77,7 @@
         return;
       }
 
-      const products = parseInStockProducts(pages);
+      const products = parseEligibleProducts(pages);
       renderProducts(container, products);
       renderControls({
         container,
@@ -99,12 +101,12 @@
     container.classList.add(GRID_CLASS);
     container.innerHTML = `
       <li class="buy2day-loader-message">
-        Loading products from ${pageCount} pages using ${getOrderbyLabel(orderby)}...
+        Loading eligible products from ${pageCount} pages using ${getOrderbyLabel(orderby)}...
       </li>
     `;
 
     if (countText) {
-      countText.textContent = "Loading in-stock products...";
+      countText.textContent = "Loading eligible products...";
     }
   }
 
@@ -121,21 +123,20 @@
     );
   }
 
-  function parseInStockProducts(pages) {
+  function parseEligibleProducts(pages) {
     const parser = new DOMParser();
 
     return pages.flatMap((html) => {
       const doc = parser.parseFromString(html, "text/html");
 
-      return Array.from(doc.querySelectorAll("li.product")).filter(isInStockProduct);
+      return Array.from(doc.querySelectorAll("li.product")).filter(isEligibleProduct);
     });
   }
 
-  function isInStockProduct(product) {
-    return (
-      !product.classList.contains("outofstock") &&
-      !(product.textContent || "").toLowerCase().includes("out of stock")
-    );
+  function isEligibleProduct(product) {
+    if (product.classList.contains("outofstock")) return false;
+    const text = (product.textContent || "").toLowerCase();
+    return !text.includes("out of stock") && !text.includes("installment");
   }
 
   function renderProducts(container, products) {
@@ -166,7 +167,7 @@
 
     if (countText) {
       countText.classList.add(HIDDEN_SITE_CONTROL_CLASS);
-      countText.textContent = `Showing ${container.querySelectorAll("li.product").length} in-stock products`;
+      countText.textContent = `Showing ${container.querySelectorAll("li.product").length} eligible products`;
     }
 
     if (siteOrdering) {
@@ -178,7 +179,7 @@
     panel.innerHTML = `
       <div class="buy2day-loader-summary">
         <strong>${container.querySelectorAll("li.product").length}</strong>
-        <span>in-stock products</span>
+        <span>eligible products</span>
         <small>${totalPages} pages, ${getOrderbyLabel(orderby)}</small>
       </div>
       <div class="buy2day-loader-controls">
@@ -285,7 +286,9 @@
   }
 
   function getProductPrice(product) {
-    const priceText = product.querySelector(".price")?.textContent || "";
+    const salePrice = product.querySelector(".price ins .woocommerce-Price-amount");
+    const anyPrice = product.querySelector(".price .woocommerce-Price-amount");
+    const priceText = (salePrice || anyPrice)?.textContent || "";
     const parsed = Number.parseFloat(priceText.replace(/[^\d.]/g, ""));
 
     return Number.isNaN(parsed) ? 0 : parsed;
@@ -499,6 +502,16 @@
         font-weight: 700 !important;
       }
 
+      ul.products.${GRID_CLASS} li.product .price del {
+        color: #9ca3af !important;
+        font-size: 12px !important;
+        font-weight: 400 !important;
+      }
+
+      ul.products.${GRID_CLASS} li.product .price ins {
+        text-decoration: none !important;
+      }
+
       ul.products.${GRID_CLASS} li.product .button {
         align-self: stretch;
         margin-top: 10px !important;
@@ -604,16 +617,16 @@
     const button = document.createElement("button");
     button.id = BUTTON_ID;
     button.type = "button";
-    button.textContent = "Load In-Stock Products";
+    button.textContent = "Load Eligible Products";
 
     button.addEventListener("click", async () => {
       button.disabled = true;
-      button.textContent = "Loading Products...";
+      button.textContent = "Loading...";
 
       try {
         await loadProducts();
       } finally {
-        button.textContent = "Load In-Stock Products";
+        button.textContent = "Load Eligible Products";
         button.disabled = false;
       }
     });

--- a/tools/check-buy2day-products.mjs
+++ b/tools/check-buy2day-products.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 const SITE_ORIGIN = "https://buy2day.pk";
-const CATEGORY_SLUG = "rewards-points-products";
+const SHOP_URL = `${SITE_ORIGIN}/shop/`;
 const PER_PAGE = 100;
 const DEFAULT_STATE_PATH = path.join("data", "buy2day-products.json");
 const DEFAULT_SUMMARY_PATH = path.join("data", "buy2day-new-products.md");
@@ -11,18 +11,16 @@ const statePath = process.env.BUY2DAY_PRODUCT_STATE_PATH || DEFAULT_STATE_PATH;
 const summaryPath = process.env.BUY2DAY_PRODUCT_SUMMARY_PATH || DEFAULT_SUMMARY_PATH;
 
 const previousState = await readPreviousState(statePath);
-const categoryId = await fetchCategoryId();
-const currentProducts = await fetchProducts(categoryId);
+const currentProducts = await fetchProducts();
 const previousProducts = previousState?.products || [];
 const previousProductIds = new Set(previousProducts.map((product) => product.id));
-const isInitialRun = !previousState;
+const isInitialRun = previousState?.source !== SHOP_URL;
 const newProducts = isInitialRun
   ? []
   : currentProducts.filter((product) => !previousProductIds.has(product.id));
 
 await writeJson(statePath, {
-  source: `${SITE_ORIGIN}/product-category/${CATEGORY_SLUG}/`,
-  categoryId,
+  source: SHOP_URL,
   total: currentProducts.length,
   products: currentProducts,
 });
@@ -41,8 +39,8 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 
 console.log(
   isInitialRun
-    ? `Initialized Buy2Day product snapshot with ${currentProducts.length} products.`
-    : `Found ${newProducts.length} new Buy2Day products out of ${currentProducts.length} current products.`,
+    ? `Initialized Buy2Day product snapshot with ${currentProducts.length} eligible products from shop.`
+    : `Found ${newProducts.length} new Buy2Day products out of ${currentProducts.length} eligible products.`,
 );
 
 async function readPreviousState(filePath) {
@@ -57,26 +55,12 @@ async function readPreviousState(filePath) {
   }
 }
 
-async function fetchCategoryId() {
-  const url = new URL("/wp-json/wp/v2/product_cat", SITE_ORIGIN);
-  url.searchParams.set("slug", CATEGORY_SLUG);
-
-  const categories = await fetchJson(url);
-  const category = categories[0];
-  if (!category?.id) {
-    throw new Error(`Could not find Buy2Day category "${CATEGORY_SLUG}".`);
-  }
-
-  return category.id;
-}
-
-async function fetchProducts(categoryId) {
+async function fetchProducts() {
   const products = [];
   let totalPages = 1;
 
   for (let page = 1; page <= totalPages; page += 1) {
     const url = new URL("/wp-json/wc/store/v1/products", SITE_ORIGIN);
-    url.searchParams.set("category", String(categoryId));
     url.searchParams.set("per_page", String(PER_PAGE));
     url.searchParams.set("page", String(page));
     url.searchParams.set("orderby", "date");
@@ -86,14 +70,22 @@ async function fetchProducts(categoryId) {
     const { data, response } = await fetchJsonWithResponse(url);
     totalPages = Number.parseInt(response.headers.get("x-wp-totalpages") || "1", 10);
 
-    products.push(...data.map(normalizeProduct));
+    products.push(...data.filter(isEligibleApiProduct).map(normalizeProduct));
   }
 
   return products;
 }
 
-async function fetchJson(url) {
-  return (await fetchJsonWithResponse(url)).data;
+function isEligibleApiProduct(product) {
+  const text = [product.name, stripHtml(product.short_description || "")].join(" ").toLowerCase();
+  return !text.includes("installment");
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 async function fetchJsonWithResponse(url) {
@@ -169,7 +161,7 @@ function buildSummary({ currentProducts, newProducts, isInitialRun }) {
     return [
       "# Buy2Day Product Snapshot Initialized",
       "",
-      `Tracked ${currentProducts.length} products in the rewards category.`,
+      `Tracked ${currentProducts.length} eligible products from the shop.`,
       "Future scheduled runs will open an issue when new products appear.",
     ].join("\n");
   }
@@ -178,7 +170,7 @@ function buildSummary({ currentProducts, newProducts, isInitialRun }) {
     return [
       "# No New Buy2Day Products",
       "",
-      `Checked ${currentProducts.length} products in the rewards category.`,
+      `Checked ${currentProducts.length} eligible products in the shop.`,
     ].join("\n");
   }
 


### PR DESCRIPTION
## Summary

- Userscript (v1.3.0) now matches `/shop/*` so the loader runs on the full Buy2Day catalog, not just the rewards-points category
- Installment-only products (e.g. items marked "installment available") are excluded from both the browser view and the GitHub Actions notification stream
- Sale items sort and display by their discounted price; the original price is shown greyed-out using the WooCommerce `del`/`ins` markup
- Backend checker drops the rewards-category API filter and scans all visible shop products; detects the source-URL change in the stored snapshot and treats the first post-migration run as an initialisation to avoid a flood of false new-product notifications

## Test plan

- [ ] Open `https://buy2day.pk/shop/` — "Load Eligible Products" button should appear
- [ ] Click the button — grid loads, installment products (e.g. Dawlance 91999 Graze) are absent
- [ ] Verify sale products (e.g. West Point WF-6813) show discounted price in green and original greyed-out
- [ ] Price sort uses the discounted price, not the original
- [ ] Rewards category page (`/product-category/rewards-points-products/`) still works as before
- [ ] Run `npm run check:buy2day-products` locally — should initialise a new snapshot from `/shop/` without opening a notification issue